### PR TITLE
Add flight search automation

### DIFF
--- a/stagehand.config.ts
+++ b/stagehand.config.ts
@@ -30,6 +30,7 @@ const StagehandConfig: ConstructorParams = {
     },
   },
   localBrowserLaunchOptions: {
+    headless: true,
     viewport: {
       width: 1024,
       height: 768,


### PR DESCRIPTION
## Summary
- headless Stagehand configuration so tests run without GUI
- add example script to search flights from Toronto to Bangalore

## Testing
- `npm run build`
- `npm start` *(fails: Google Generative AI API key is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844c2aabdbc83219d3902e3604f2c48